### PR TITLE
chore: apply latest nightly rustfmt

### DIFF
--- a/ruint-macro/src/lib.rs
+++ b/ruint-macro/src/lib.rs
@@ -208,7 +208,8 @@ impl Transformer {
         };
 
         // Parse `value` into limbs.
-        // At this point we are confident the literal was for us, so we throw errors.
+        // At this point we are confident the literal was for us, so we throw
+        // errors.
         let limbs = parse_digits(value)?;
 
         // Pad limbs to the correct length.

--- a/src/algorithms/div/knuth.rs
+++ b/src/algorithms/div/knuth.rs
@@ -136,7 +136,8 @@ pub unsafe fn div_nxm(numerator: &mut [u64], divisor: &mut [u64]) {
     let mut q_high = 0;
     #[allow(clippy::range_plus_one)] // Inclusive ranges optimize worse.
     for j in (0..m + 1).rev() {
-        // Fetch the first three limbs of the shifted numerator starting at `j + n`.
+        // Fetch the first three limbs of the shifted numerator starting at `j +
+        // n`.
         let (n21, n0) = {
             let n2 = numerator.get(j + n).copied().unwrap_or_default();
             let n21 = DW::join(n2, numerator[j + n - 1]);
@@ -163,7 +164,8 @@ pub unsafe fn div_nxm(numerator: &mut [u64], divisor: &mut [u64]) {
             if q != 0 {
                 // Subtract the quotient times the divisor from the remainder.
                 // We already have the highest 128 bit, so we can reduce the
-                // computation. We still need to carry propagate into these limbs.
+                // computation. We still need to carry propagate into these
+                // limbs.
                 let borrow = if shift == 0 {
                     // SAFETY: both slices have length `n - 2`.
                     let borrow =
@@ -173,8 +175,9 @@ pub unsafe fn div_nxm(numerator: &mut [u64], divisor: &mut [u64]) {
                     numerator[j + n - 1] = DW::high(r);
                     borrow
                 } else {
-                    // OPT: Can we re-use `r` here somehow? The problem is we can not just
-                    // shift the `r` or `borrow` because we need to accurately reproduce
+                    // OPT: Can we re-use `r` here somehow? The problem is we
+                    // can not just shift the `r` or
+                    // `borrow` because we need to accurately reproduce
                     // the remainder and carry in the middle of a limb.
                     // SAFETY: both slices have length `n`.
                     let borrow = unsafe { submul_nx1(&mut numerator[j..j + n], divisor, q) };
@@ -183,7 +186,8 @@ pub unsafe fn div_nxm(numerator: &mut [u64], divisor: &mut [u64]) {
                 };
 
                 // If we have a carry then the quotient was one too large.
-                // We correct by decrementing the quotient and adding one divisor back.
+                // We correct by decrementing the quotient and adding one
+                // divisor back.
                 if unlikely(borrow) {
                     q = q.wrapping_sub(1);
                     let carry = carrying_add_n(&mut numerator[j..j + n], &divisor[..n], false);

--- a/src/algorithms/div/mod.rs
+++ b/src/algorithms/div/mod.rs
@@ -61,7 +61,8 @@ pub(crate) fn div_inlined(numerator: &mut [u64], divisor: &mut [u64]) {
     // Trim most significant zeros from divisor.
     let divisor = super::trim_end_zeros_mut(divisor);
     if divisor.is_empty() {
-        // Force a division by 0 panic, which is smaller in code size than an `assert!`.
+        // Force a division by 0 panic, which is smaller in code size than an
+        // `assert!`.
         #[allow(unconditional_panic, clippy::all)]
         let _ = 0 / 0;
     }

--- a/src/algorithms/gcd/matrix.rs
+++ b/src/algorithms/gcd/matrix.rs
@@ -137,7 +137,8 @@ impl Matrix {
         let mut q10 = 0_u64;
         let mut q11 = 1_u64;
         loop {
-            // Loop is unrolled once to avoid swapping variables and tracking parity.
+            // Loop is unrolled once to avoid swapping variables and tracking
+            // parity.
             let q = r0 / r1;
             r0 -= q * r1;
             q00 += q * q10;
@@ -253,8 +254,9 @@ impl Matrix {
         debug_assert!(a2 >= LIMIT);
         debug_assert!(a3 < LIMIT);
 
-        // Use Jebelean's exact condition to determine which outputs are correct.
-        // Statistically, i + 2 should be correct about two-thirds of the time.
+        // Use Jebelean's exact condition to determine which outputs are
+        // correct. Statistically, i + 2 should be correct about
+        // two-thirds of the time.
         if even {
             // Test i + 1 (even)
             debug_assert!(a2 >= v2);
@@ -314,7 +316,8 @@ impl Matrix {
         if q == Matrix::IDENTITY {
             return q;
         }
-        // We can return q here and have a perfectly valid single-word Lehmer GCD.
+        // We can return q here and have a perfectly valid single-word Lehmer
+        // GCD.
         q
         // OPT: Fix the below method to get double-word Lehmer GCD.
 

--- a/src/base_convert.rs
+++ b/src/base_convert.rs
@@ -158,7 +158,8 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
             }
 
             // Add digit to result
-            // SAFETY: `result.limbs` and `power.as_limbs()` are both `[u64; LIMBS]`.
+            // SAFETY: `result.limbs` and `power.as_limbs()` are both `[u64;
+            // LIMBS]`.
             let overflow = unsafe { addmul_nx1(&mut result.limbs, power.as_limbs(), digit) };
             if overflow != 0 || result.limbs[LIMBS - 1] > Self::MASK {
                 return Err(BaseConvertError::Overflow);

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -1237,16 +1237,17 @@ mod tests {
             (Uint::<64, 1>::from(20), true)
         );
 
-        // Test: Two limbs right shift from 0x0010_0000_0000_0000 and 0 by 1 bit.
-        // Expects resulting limbs: [0x0080_0000_0000_000, 0] with no fractional part.
+        // Test: Two limbs right shift from 0x0010_0000_0000_0000 and 0 by 1
+        // bit. Expects resulting limbs: [0x0080_0000_0000_000, 0] with
+        // no fractional part.
         assert_eq!(
             Uint::<65, 2>::from_limbs([0x0010_0000_0000_0000, 0]).overflowing_shr(1),
             (Uint::<65, 2>::from_limbs([0x0008_0000_0000_0000, 0]), false)
         );
 
         // Test: Shift beyond single limb capacity with MAX value.
-        // Expects the highest possible value in 256-bit representation with a detected
-        // fractional part.
+        // Expects the highest possible value in 256-bit representation with a
+        // detected fractional part.
         assert_eq!(
             Uint::<256, 4>::MAX.overflowing_shr(65),
             (

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -587,7 +587,8 @@ mod tests {
     fn test_from_slice_too_large_returns_none() {
         // Regression: `BITS % 64` in 57..=63 gives `BYTES = 8 * LIMBS`, so the
         // full-limb fast path was taken even though the top limb is masked.
-        // An all-ones input overflows the mask and must return `None`, not panic.
+        // An all-ones input overflows the mask and must return `None`, not
+        // panic.
         assert_eq!(Uint::<60, 1>::try_from_be_slice(&[0xff; 8]), None);
         assert_eq!(Uint::<60, 1>::try_from_le_slice(&[0xff; 8]), None);
         assert_eq!(Uint::<121, 2>::try_from_be_slice(&[0xff; 16]), None);

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -123,8 +123,8 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     pub fn is_zero(&self) -> bool {
         if cfg!(any(target_arch = "riscv32", target_arch = "riscv64")) {
             // On riscv, comparing against a materialized `Self::ZERO` becomes a
-            // `bcmp`/`memcmp` libcall; OR-accumulating the limbs avoids both the
-            // libcall and the zero temporary.
+            // `bcmp`/`memcmp` libcall; OR-accumulating the limbs avoids both
+            // the libcall and the zero temporary.
             let mut acc = 0;
             let mut i = 0;
             while i < LIMBS {
@@ -162,7 +162,8 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
             u64(x, y) => return x == y,
             u128(x, y) => return x == y,
         });
-        // TODO: Replace with `self == other` and deprecate once `PartialEq` is const.
+        // TODO: Replace with `self == other` and deprecate once `PartialEq` is
+        // const.
         let a = self.as_limbs();
         let b = other.as_limbs();
         let mut equal_count = 0usize;

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -62,7 +62,8 @@ macro_rules! impl_fmt {
                     return <u128 as $tr>::fmt(&small, f);
                 }
 
-                // Use `BITS` for all bases since `generic_const_exprs` is not yet stable.
+                // Use `BITS` for all bases since `generic_const_exprs` is not yet
+                // stable.
                 let mut s = StackString::<BITS>::new();
                 let mut first = true;
                 for spigot in self.to_base_be_2(<$base>::MAX) {

--- a/src/from.rs
+++ b/src/from.rs
@@ -533,9 +533,9 @@ impl<const BITS: usize, const LIMBS: usize> TryFrom<f64> for Uint<BITS, LIMBS> {
 
         // Reject non-finite inputs up front, independent of BITS. The overflow
         // check below keys off the unbiased exponent (1024 for NaN/inf), which
-        // stops exceeding BITS once BITS >= 1025, so it cannot be relied upon to
-        // catch these. NaN is rejected before the sign split so that a
-        // negatively-signed NaN is `NotANumber`, not `ValueNegative`.
+        // stops exceeding BITS once BITS >= 1025, so it cannot be relied upon
+        // to catch these. NaN is rejected before the sign split so that
+        // a negatively-signed NaN is `NotANumber`, not `ValueNegative`.
         if f.is_nan() {
             return Err(ToUintError::NotANumber(BITS));
         }
@@ -576,8 +576,9 @@ impl<const BITS: usize, const LIMBS: usize> TryFrom<f64> for Uint<BITS, LIMBS> {
             _ => unreachable!(),
         };
 
-        // Helper: produce integer magnitude for |f| given an unbiased exponent `e`,
-        // using round-to-nearest, ties-to-even, then interpreted modulo 2^BITS by Uint.
+        // Helper: produce integer magnitude for |f| given an unbiased exponent
+        // `e`, using round-to-nearest, ties-to-even, then interpreted
+        // modulo 2^BITS by Uint.
         let compute_mag = |e: usize| -> Self {
             if e < significand_bits {
                 // Right shift with round-to-nearest, ties-to-even
@@ -595,13 +596,15 @@ impl<const BITS: usize, const LIMBS: usize> TryFrom<f64> for Uint<BITS, LIMBS> {
             }
         };
 
-        // Negative values: return ValueNegative with wrapped two's-complement payload.
-        // Handle |value| < 1 without going through the saturating exponent path to
-        // preserve correct rounding: ties-to-even at 0.5, otherwise nearest.
+        // Negative values: return ValueNegative with wrapped two's-complement
+        // payload. Handle |value| < 1 without going through the
+        // saturating exponent path to preserve correct rounding:
+        // ties-to-even at 0.5, otherwise nearest.
         if sign == Sign::Negative {
             if exponent < exponent_bias {
                 // |value| < 1
-                // Rounds to 0 for −0.5 ≤ value < 0.0, and to 1 for −1.0 < value < −0.5.
+                // Rounds to 0 for −0.5 ≤ value < 0.0, and to 1 for −1.0 < value
+                // < −0.5.
                 if value >= -0.5 {
                     return Err(ToUintError::ValueNegative(BITS, Self::ZERO));
                 } else {
@@ -622,15 +625,16 @@ impl<const BITS: usize, const LIMBS: usize> TryFrom<f64> for Uint<BITS, LIMBS> {
             return if BITS == 0 {
                 Err(ToUintError::ValueTooLarge(BITS, Self::ZERO))
             } else {
-                // We already handled value < 0.5 above; here 0.5 <= value < 1.0 → 1.
+                // We already handled value < 0.5 above; here 0.5 <= value < 1.0
+                // → 1.
                 Ok(Self::ONE)
             };
         }
         exponent -= exponent_bias;
 
         // If the value is infinity, saturate.
-        // If the value is too large for the integer type, wrap (drop high bits) and
-        // return it in the error.
+        // If the value is too large for the integer type, wrap (drop high bits)
+        // and return it in the error.
         if exponent >= fixint_bits {
             // NaN and infinity were already handled above, so `value` is finite
             // here and this branch only covers genuinely too-large magnitudes.
@@ -648,8 +652,9 @@ impl<const BITS: usize, const LIMBS: usize> TryFrom<f64> for Uint<BITS, LIMBS> {
         // In-range: produce the integer normally.
         let r = compute_mag(exponent);
 
-        // Match old impl: if rounding bumps us across 2^BITS (only possible when
-        // exponent == BITS - 1), report ValueTooLarge with the wrapped payload.
+        // Match old impl: if rounding bumps us across 2^BITS (only possible
+        // when exponent == BITS - 1), report ValueTooLarge with the
+        // wrapped payload.
         if sign == Sign::Positive
             && fixint_bits > 0
             && exponent == fixint_bits - 1
@@ -858,8 +863,9 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         let hi = limbs[li];
         let lo = if li > 0 { limbs[li - 1] } else { 0 };
 
-        // Concatenate [hi:64][lo:64] and drop the low bits so the 54-bit window is at
-        // LSB. Correct alignment: shift = 64 + off - SIG  (not SIG+1!)
+        // Concatenate [hi:64][lo:64] and drop the low bits so the 54-bit window
+        // is at LSB. Correct alignment: shift = 64 + off - SIG  (not
+        // SIG+1!)
         let shift = 64 + off as usize - SIG; // range 11..=74
         debug_assert!((11..=74).contains(&shift));
 
@@ -1056,9 +1062,9 @@ mod test {
         assert!(f32::from(Uint::<F32_BITS, F_32LIMBS>::MAX).is_infinite());
     }
 
-    // Non-finite f64 inputs must be rejected regardless of BITS. For BITS >= 1025
-    // the unbiased exponent of NaN/inf (1024) no longer exceeds BITS, so the
-    // overflow check alone does not fire.
+    // Non-finite f64 inputs must be rejected regardless of BITS. For BITS >=
+    // 1025 the unbiased exponent of NaN/inf (1024) no longer exceeds BITS,
+    // so the overflow check alone does not fire.
     #[test]
     fn correctness_8_7_2026_try_from_nonfinite_large_bits() {
         type U2048 = Uint<2048, 32>;
@@ -1226,7 +1232,8 @@ mod test {
         // Convert mantissa * 2^(exponent - 52) to Uint
         #[allow(clippy::cast_possible_truncation)] // exponent is small-ish
         if exponent as usize > BITS + 52 {
-            // Wrapped value is zero because the value is extended with zero bits.
+            // Wrapped value is zero because the value is extended with zero
+            // bits.
             return Err(ToUintError::ValueTooLarge(BITS, Uint::ZERO));
         }
         if exponent <= 52 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,7 +242,8 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
     #[track_caller]
     pub const fn from_limbs(limbs: [u64; LIMBS]) -> Self {
         if Self::SHOULD_MASK {
-            // FEATURE: (BLOCKED) Add `<{BITS}>` to the type when Display works in const fn.
+            // FEATURE: (BLOCKED) Add `<{BITS}>` to the type when Display works
+            // in const fn.
             assert!(
                 limbs[LIMBS - 1] <= Self::MASK,
                 "Value too large for this Uint"

--- a/src/log.rs
+++ b/src/log.rs
@@ -45,8 +45,9 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         if self.is_zero() {
             return None;
         }
-        // The base-2 logarithm is the index of the highest set bit. Computing it
-        // directly avoids materializing `2`, which does not fit when `BITS < 2`.
+        // The base-2 logarithm is the index of the highest set bit. Computing
+        // it directly avoids materializing `2`, which does not fit when
+        // `BITS < 2`.
         Some(self.bit_len() - 1)
     }
 
@@ -70,12 +71,13 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         // Find approximate result
         #[allow(clippy::cast_precision_loss)] // Casting base to `f64` is fine.
         let result = self.approx_log2() / base.approx_log2();
-        // We handled edge cases above, so the result should be normal and fit `Self`.
+        // We handled edge cases above, so the result should be normal and fit
+        // `Self`.
         assert!(result.is_normal());
         let mut result = result.try_into().unwrap();
 
-        // Adjust result to get the exact value. At most one of these should happen, but
-        // we loop regardless.
+        // Adjust result to get the exact value. At most one of these should
+        // happen, but we loop regardless.
         loop {
             if let Some(value) = base.checked_pow(result) {
                 if value > self {
@@ -186,16 +188,17 @@ mod tests {
 
     #[test]
     fn test_checked_log_tiny_bits() {
-        // The `checked_*` variants return an `Option` and must never panic, even
-        // when the base constant (2 or 10) is too large for the bit-width.
+        // The `checked_*` variants return an `Option` and must never panic,
+        // even when the base constant (2 or 10) is too large for the
+        // bit-width.
 
         // BITS < 2: the type cannot represent 2.
         assert_eq!(Uint::<0, 0>::ZERO.checked_log2(), None);
         assert_eq!(Uint::<1, 1>::ZERO.checked_log2(), None);
         assert_eq!(Uint::<1, 1>::from(1u64).checked_log2(), Some(0));
 
-        // `checked_log` with a base that is 0 or 1 (all bases fit in `Uint<1, 1>`)
-        // returns None rather than panicking on `Self::from(2)`.
+        // `checked_log` with a base that is 0 or 1 (all bases fit in `Uint<1,
+        // 1>`) returns None rather than panicking on `Self::from(2)`.
         let one = Uint::<1, 1>::from(1u64);
         assert_eq!(Uint::<1, 1>::ZERO.checked_log(one), None);
         assert_eq!(one.checked_log(one), None);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -183,7 +183,8 @@ macro_rules! let_double_bits {
         let mut double = [[0u64; 2]; LIMBS];
         let double_len = crate::nlimbs(2 * BITS);
         debug_assert!(2 * LIMBS >= double_len);
-        // SAFETY: `[[u64; 2]; LIMBS] == [u64; 2 * LIMBS] >= [u64; nlimbs(2 * BITS)]`.
+        // SAFETY: `[[u64; 2]; LIMBS] == [u64; 2 * LIMBS] >= [u64; nlimbs(2 *
+        // BITS)]`.
         let $id = unsafe {
             core::slice::from_raw_parts_mut(double.as_mut_ptr().cast::<u64>(), double_len)
         };

--- a/src/modular.rs
+++ b/src/modular.rs
@@ -36,8 +36,8 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
             return Self::ZERO;
         }
 
-        // This is not going to truncate with the final cast because the modulus value
-        // is 64 bits.
+        // This is not going to truncate with the final cast because the modulus
+        // value is 64 bits.
         #[allow(clippy::cast_possible_truncation)]
         if BITS <= 64 {
             self.limbs[0] =

--- a/src/root.rs
+++ b/src/root.rs
@@ -46,7 +46,8 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
         }
 
         // Create a first guess.
-        // Root should be less than the value, so approx_pow2 should always succeed.
+        // Root should be less than the value, so approx_pow2 should always
+        // succeed.
         #[allow(clippy::cast_precision_loss)] // Approximation is good enough.
         #[allow(clippy::cast_sign_loss)] // Result should be positive.
         let mut result = Self::approx_pow2(self.approx_log2() / degree as f64).unwrap();
@@ -61,8 +62,8 @@ impl<const BITS: usize, const LIMBS: usize> Uint<BITS, LIMBS> {
             // OPT: This could benefit from single-limb multiplication
             // and division.
             //
-            // OPT: The division can be turned into bit-shifts when the degree is a power of
-            // two.
+            // OPT: The division can be turned into bit-shifts when the degree
+            // is a power of two.
             let division = result
                 .checked_pow(deg_m1)
                 .map_or(Self::ZERO, |power| self / power);

--- a/src/support/alloy_rlp.rs
+++ b/src/support/alloy_rlp.rs
@@ -78,14 +78,14 @@ impl<const BITS: usize, const LIMBS: usize> Decodable for Uint<BITS, LIMBS> {
     fn decode(buf: &mut &[u8]) -> Result<Self, Error> {
         let bytes = Header::decode_bytes(buf, false)?;
 
-        // The RLP spec states that deserialized positive integers with leading zeroes
-        // get treated as invalid.
+        // The RLP spec states that deserialized positive integers with leading
+        // zeroes get treated as invalid.
         //
         // See:
         // https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/
         //
-        // To check this, we only need to check if the first byte is zero to make sure
-        // there are no leading zeros
+        // To check this, we only need to check if the first byte is zero to
+        // make sure there are no leading zeros
         if !bytes.is_empty() && bytes[0] == 0 {
             return Err(Error::LeadingZero);
         }

--- a/src/support/bincode_2.rs
+++ b/src/support/bincode_2.rs
@@ -53,7 +53,8 @@ impl<Context, const BITS: usize, const LIMBS: usize> Decode<Context> for Uint<BI
         decoder.claim_bytes_read(len)?;
         let mut buffer = [0u64; LIMBS]; // not possible to use Self::BYTES or nbytes(BITS) here.
         let slice = unsafe {
-            // SAFETY: We ensure that the buffer is large enough to hold the bytes
+            // SAFETY: We ensure that the buffer is large enough to hold the
+            // bytes
             let ptr = buffer.as_mut_ptr().cast::<u8>();
             core::slice::from_raw_parts_mut(ptr, Self::BYTES)
         };

--- a/src/support/bn_rs.rs
+++ b/src/support/bn_rs.rs
@@ -18,8 +18,8 @@ impl<const BITS: usize, const LIMBS: usize> TryFrom<&BN> for Uint<BITS, LIMBS> {
             return Err(ToUintError::ValueTooLarge(BITS, Self::ZERO));
         }
         // Binding for `toArray`
-        // `a.toArray(endian, length)` - convert to byte array, and optionally zero pad
-        // to length, throwing if already exceeding. <https://github.com/indutny/bn.js/blob/5df40f81ea8afb835b909bb7c21e0833cdeb6a30/lib/bn.js#L573>
+        // `a.toArray(endian, length)` - convert to byte array, and optionally
+        // zero pad to length, throwing if already exceeding. <https://github.com/indutny/bn.js/blob/5df40f81ea8afb835b909bb7c21e0833cdeb6a30/lib/bn.js#L573>
         value.to_array("le".into(), 0).map_or_else(
             |_| Err(ToUintError::NotANumber(BITS)),
             |bytes| {

--- a/src/support/der.rs
+++ b/src/support/der.rs
@@ -139,8 +139,9 @@ impl<const BITS: usize, const LIMBS: usize> From<&Uint<BITS, LIMBS>> for DerUint
             Self::new(&[0]).unwrap()
         } else {
             // Panics:
-            // The only error is if the length is more than can be represented in u32.
-            // This is well outside of the inteded usecase for this library.
+            // The only error is if the length is more than can be represented
+            // in u32. This is well outside of the inteded usecase
+            // for this library.
             Self::new(&uint.to_be_bytes_trimmed_vec()).unwrap()
         }
     }

--- a/src/support/fastrlp_03.rs
+++ b/src/support/fastrlp_03.rs
@@ -85,14 +85,14 @@ impl<const BITS: usize, const LIMBS: usize> Decodable for Uint<BITS, LIMBS> {
         let bytes = &buf[..header.payload_length];
         *buf = &buf[header.payload_length..];
 
-        // The RLP spec states that deserialized positive integers with leading zeroes
-        // get treated as invalid.
+        // The RLP spec states that deserialized positive integers with leading
+        // zeroes get treated as invalid.
         //
         // See:
         // https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/
         //
-        // To check this, we only need to check if the first byte is zero to make sure
-        // there are no leading zeros
+        // To check this, we only need to check if the first byte is zero to
+        // make sure there are no leading zeros
         if !bytes.is_empty() && bytes[0] == 0 {
             return Err(DecodeError::LeadingZero);
         }

--- a/src/support/fastrlp_04.rs
+++ b/src/support/fastrlp_04.rs
@@ -85,14 +85,14 @@ impl<const BITS: usize, const LIMBS: usize> Decodable for Uint<BITS, LIMBS> {
         let bytes = &buf[..header.payload_length];
         *buf = &buf[header.payload_length..];
 
-        // The RLP spec states that deserialized positive integers with leading zeroes
-        // get treated as invalid.
+        // The RLP spec states that deserialized positive integers with leading
+        // zeroes get treated as invalid.
         //
         // See:
         // https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/
         //
-        // To check this, we only need to check if the first byte is zero to make sure
-        // there are no leading zeros
+        // To check this, we only need to check if the first byte is zero to
+        // make sure there are no leading zeros
         if !bytes.is_empty() && bytes[0] == 0 {
             return Err(DecodeError::LeadingZero);
         }

--- a/src/support/postgres.rs
+++ b/src/support/postgres.rs
@@ -99,11 +99,12 @@ impl<const BITS: usize, const LIMBS: usize> ToSql for Uint<BITS, LIMBS> {
             // Binary strings
             Type::BYTEA => out.put_slice(&self.to_be_bytes_vec()),
             Type::BIT | Type::VARBIT => {
-                // Bit in little-endian so the the first bit is the least significant.
-                // Length must be at least one bit.
+                // Bit in little-endian so the the first bit is the least
+                // significant. Length must be at least one bit.
                 if BITS == 0 {
                     if *ty == Type::BIT {
-                        // `bit(0)` is not a valid type, but varbit can be empty.
+                        // `bit(0)` is not a valid type, but varbit can be
+                        // empty.
                         return Err(Box::new(WrongType::new::<Self>(ty.clone())));
                     }
                     out.put_i32(0);
@@ -482,7 +483,8 @@ mod tests {
     // This test requires a live postgresql server.
     // To start a server, run:
     //
-    //     docker run -it --rm -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres
+    //     docker run -it --rm -e POSTGRES_PASSWORD=postgres -p 5432:5432
+    // postgres
     //
     // Then run the test using:
     //
@@ -492,7 +494,8 @@ mod tests {
     #[test]
     #[ignore = "requires a live postgresql server"]
     fn test_postgres() {
-        // docker run -it --rm -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres
+        // docker run -it --rm -e POSTGRES_PASSWORD=postgres -p 5432:5432
+        // postgres
         let client = Client::connect("postgresql://postgres:postgres@localhost", NoTls).unwrap();
         let client = Mutex::new(client);
 

--- a/src/support/pyo3.rs
+++ b/src/support/pyo3.rs
@@ -108,8 +108,8 @@ impl<'a, const BITS: usize, const LIMBS: usize> FromPyObject<'a> for Uint<BITS, 
 
         // Handle error from `_PyLong_AsByteArray`.
         if py_result != 0 {
-            // A TypeError is set if the value is negative and an Overflow error if the
-            // value does not fit `raw.len()` bytes.
+            // A TypeError is set if the value is negative and an Overflow error
+            // if the value does not fit `raw.len()` bytes.
             return Err(PyErr::fetch(ob.py()));
         }
 

--- a/src/support/serde.rs
+++ b/src/support/serde.rs
@@ -225,8 +225,8 @@ mod tests {
 
     #[test]
     fn test_serde_invalid_size_error() {
-        // Test that if we add a character to a value that is already the max length for
-        // the given number of bits, we get an error.
+        // Test that if we add a character to a value that is already the max
+        // length for the given number of bits, we get an error.
         const_for!(BITS in SIZES {
             const LIMBS: usize = nlimbs(BITS);
             let value = Uint::<BITS, LIMBS>::MAX;


### PR DESCRIPTION
## Summary

- Apply formatting emitted by the latest nightly rustfmt
- Restore the rolling-nightly formatting check

## Testing

- `cargo +nightly-2026-08-31 fmt --all -- --check`
- `git diff --check`

Prompted by: @DaniPopes