### PR TITLE
chore: release 1.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.20.1] - 2026-09-07
+
 ### Added
 
 - Implement shifts and shift assignments for all primitive integer types on every target, including `u64`/`i64` on 32-bit targets and `u128`/`i128`, without truncating oversized shift amounts ([#634])
@@ -572,7 +574,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- links to version -->
 
-[unreleased]: https://github.com/alloy-rs/ruint/compare/v1.20.0...HEAD
+[unreleased]: https://github.com/alloy-rs/ruint/compare/v1.20.1...HEAD
+[1.20.1]: https://github.com/alloy-rs/ruint/releases/tag/v1.20.1
 [1.20.0]: https://github.com/alloy-rs/ruint/releases/tag/v1.20.0
 [1.19.0]: https://github.com/alloy-rs/ruint/releases/tag/v1.19.0
 [1.18.0]: https://github.com/alloy-rs/ruint/releases/tag/v1.18.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruint"
 description = "Unsigned integer type with const-generic bit length"
-version = "1.20.0"
+version = "1.20.1"
 keywords = ["uint"]
 categories = ["mathematics"]
 include = [".cargo/", "src/", "README.md"]


### PR DESCRIPTION
Prepare the 1.20.1 patch release with the primitive shift fixes from #634. This updates the crate version and moves the unreleased changelog entry into the dated 1.20.1 section.